### PR TITLE
Apply Continue-On-Error to pkg compare

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,4 +1,4 @@
-name: Java CI with Gradle
+name: Gradle Build and Compare Package
 
 on:
   pull_request:
@@ -81,6 +81,7 @@ jobs:
           name: drop
           path: artifacts/previous/      
       - name: Run PKG Diff 
+        continue-on-error: true
         run: |
             sudo apt install pkgdiff 
             pkgdiff -hide-unchanged ${{ env.PRIOR_PKG_DIFF }} ${{ env.CURRENT_PKG_DIFF }}


### PR DESCRIPTION
Apply continue-on-error=true to the pkg diff compare job. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/305)