### PR TITLE
Increase Heap Size to Unblock Preview Release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: "com.github.ben-manes.versions"
 android {
     compileSdkVersion 32
 
+    dexOptions {
+       javaMaxHeapSize "3g"
+    }
+
     defaultConfig {
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Heap size needs to be increased to unblock release, android specific issue. 
https://github.com/microsoftgraph/msgraph-beta-sdk-java/actions/runs/2958568056/jobs/4732109286



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/383)