### PR TITLE
V6 remove backing store param

### DIFF
--- a/src/main/java/com/microsoft/graph/beta/serviceclient/GraphServiceClient.java
+++ b/src/main/java/com/microsoft/graph/beta/serviceclient/GraphServiceClient.java
@@ -1,6 +1,7 @@
 package com.microsoft.graph.beta.serviceclient;
 
 import com.microsoft.graph.core.CoreConstants;
+import com.microsoft.graph.core.authentication.AzureIdentityAuthenticationProvider;
 import com.microsoft.graph.core.requests.BaseGraphRequestAdapter;
 import com.microsoft.graph.core.requests.BatchRequestBuilder;
 import com.microsoft.graph.core.requests.options.GraphClientOption;
@@ -11,8 +12,6 @@ import com.microsoft.graph.beta.info.Constants;
 import com.microsoft.kiota.RequestAdapter;
 import com.microsoft.kiota.authentication.AnonymousAuthenticationProvider;
 import com.microsoft.kiota.authentication.AuthenticationProvider;
-import com.microsoft.kiota.authentication.AzureIdentityAuthenticationProvider;
-import com.microsoft.kiota.store.BackingStoreFactory;
 import com.microsoft.kiota.store.InMemoryBackingStoreFactory;
 
 import com.azure.core.credential.TokenCredential;
@@ -40,7 +39,7 @@ public class GraphServiceClient extends com.microsoft.graph.beta.BaseGraphServic
      * @param requestAdapter The request adapter to use to execute the requests.
      */
     public GraphServiceClient(@Nonnull RequestAdapter requestAdapter) {
-        this(requestAdapter, new InMemoryBackingStoreFactory());
+        super(requestAdapter, new InMemoryBackingStoreFactory());
         this.graphServiceClientRequestAdapter = requestAdapter;
     }
     /**
@@ -74,51 +73,6 @@ public class GraphServiceClient extends com.microsoft.graph.beta.BaseGraphServic
     @SuppressWarnings("LambdaLast")
     public GraphServiceClient(@Nonnull TokenCredential tokenCredential, @Nullable String... scopes) {
         this(new AzureIdentityAuthenticationProvider(tokenCredential, null, scopes));
-    }
-    /**
-     * Instantiates a new GraphServiceClient and sets the default values.
-     * @param requestAdapter The request adapter to use to execute the requests.
-     * @param backingStoreFactory The backing store factory to use to create backing stores.
-     */
-    public GraphServiceClient(@Nonnull RequestAdapter requestAdapter, @Nonnull BackingStoreFactory backingStoreFactory) {
-        super(requestAdapter, backingStoreFactory);
-        this.graphServiceClientRequestAdapter = requestAdapter;
-    }
-    /**
-     * Instantiate the GraphServiceClient using an AuthenticationProvider and BackingStoreFactory.
-     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
-     * @param backingStoreFactory The backing store factory to use to create backing stores.
-     */
-    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider, @Nonnull BackingStoreFactory backingStoreFactory) {
-        this(new BaseGraphRequestAdapter(authenticationProvider, null, "beta" , getGraphClientOptions()), backingStoreFactory);
-    }
-    /**
-     * Instantiate the GraphServiceClient using an AuthenticationProvider, OkHttpClient, and BackingStoreFactory.
-     * @param authenticationProvider The AuthenticationProvider for this GraphServiceClient.
-     * @param client The OkHttpClient for the GraphServiceClient.
-     * @param backingStoreFactory The backing store factory to use to create backing stores.
-     */
-    @SuppressWarnings("LambdaLast")
-    public GraphServiceClient(@Nonnull AuthenticationProvider authenticationProvider, @Nonnull OkHttpClient client, @Nonnull BackingStoreFactory backingStoreFactory) {
-        this(new BaseGraphRequestAdapter(authenticationProvider, null, "beta", client), backingStoreFactory);
-    }
-    /**
-     * Instantiate the GraphServiceClient using an OkHttpClient and BackingStoreFactory.
-     * @param client The OkHttpClient for the GraphServiceClient.
-     * @param backingStoreFactory The backing store factory to use to create backing stores.
-     */
-    public GraphServiceClient(@Nonnull OkHttpClient client, @Nonnull BackingStoreFactory backingStoreFactory) {
-        this(new AnonymousAuthenticationProvider(), client, backingStoreFactory);
-    }
-    /**
-     * Instantiate the GraphServiceClient using a TokenCredential, Scopes, and BackingStoreFactory.
-     * @param tokenCredential The TokenCredential for this GraphServiceClient.
-     * @param backingStoreFactory The backing store factory to use to create backing stores.
-     * @param scopes The Scopes for this GraphServiceClient.
-     */
-    @SuppressWarnings("LambdaLast")
-    public GraphServiceClient(@Nonnull TokenCredential tokenCredential, @Nonnull BackingStoreFactory backingStoreFactory,  @Nullable String... scopes) {
-        this(new AzureIdentityAuthenticationProvider(tokenCredential, null, scopes), backingStoreFactory);
     }
     /**
      * Sets the RequestAdapter for the GraphServiceClient.


### PR DESCRIPTION
Remove BackingStoreFactory param from GraphServiceClient constructors.

Also, change import statement for AzureIdentityAuthenticationProvider
com.microsoft.kiota.authentication.AzureIdentityAuthenticationProvider -> com.microsoft.graph.core.authentication.AzureIdentityAuthenticationProvider

The Core implementation provides the correct hosts by utilizing the implementation of AzureIdentityAccessTokenProvider in Core.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/808)