### PR TITLE
Trigger maven releases on tags by release-please only

### DIFF
--- a/.github/workflows/preview-and-release.yml
+++ b/.github/workflows/preview-and-release.yml
@@ -54,7 +54,7 @@ jobs:
         run: ./gradlew $PREVIEW_TASK
 
   maven_Release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && ${{ github.actor == 'release-please[bot]' }}
     environment:
       name: maven_central_release
     runs-on: ubuntu-latest


### PR DESCRIPTION
closes out pending steps to remove manual approval on GitHub environments described in https://github.com/microsoftgraph/msgraph-sdk-java/issues/1978#issuecomment-2127366805
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/965)