### PR TITLE
refactor: consolidate Dependabot dependency groups and clean up pom.xml references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directories:
   - "/"
   - "/java-8"
+  - "/android"
   schedule:
     interval: weekly
     time: "09:00" # 9am UTC
@@ -12,51 +13,28 @@ updates:
     kiota-dependencies:
       patterns:
         - "*kiota*"
+    microsoft-graph:
+      patterns:
+        - "*microsoft-graph*"
     junit-dependencies:
       patterns:
         - "*junit*"
     open-telemetry:
       patterns:
         - "*opentelemetry*"
-    
-- package-ecosystem: gradle
-  directory: "/android"
-  schedule:
-    interval: weekly
-    time: "10:00" # 10am UTC. Scheduled after core java dependencies to prevent duplicate PRs
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
+    android-build-tools:
       patterns:
-        - "*kiota*"
-    junit-dependencies:
-      patterns:
-        - "*junit*"
-    open-telemetry:
-      patterns:
-        - "*opentelemetry*"
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  groups:
-    kiota-dependencies:
-      patterns:
-        - "*kiota*"
-    junit-dependencies:
-      patterns:
-        - "*junit*"
-    open-telemetry:
-      patterns:
-        - "*opentelemetry*"
+        - "*android*"
+        - "*gradle-enterprise*"
+        - "*gradle-util*"
+        - "*gradle-versions*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
   groups:
-    github-actions-dependencies:
+    all-actions:
       patterns:
-        - "actions/*"
+        - "*"
 

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -83,3 +83,19 @@ jobs:
           else
             exit 1
           fi
+
+  dependency-submission:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: gradle
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ java {
 sourceSets {
     main {
         java {
-            exclude 'pom.xml'
         }
     }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,12 +16,7 @@
             "extra-files": [
                 "gradle.properties",
                 "README.md",
-                "src/main/java/com/microsoft/graph/beta/info/Constants.java",
-                {
-                    "type": "xml",
-                    "path": "pom.xml",
-                    "xpath": "//project/version"
-                }
+                "src/main/java/com/microsoft/graph/beta/info/Constants.java"
             ]
         }
     },


### PR DESCRIPTION
Replicates the changes from https://github.com/microsoftgraph/msgraph-sdk-java/pull/2602 for the beta SDK.

## Changes
- Consolidate 3 Dependabot entries into 2 (single gradle + github-actions)
- Merge gradle directories (/, /java-8, /android) into one entry
- Remove maven ecosystem entry (no pom.xml exists in this repo)
- Add dependency groups: microsoft-graph, android-build-tools, all-actions
- Add Gradle dependency submission job to gradle-build.yml
- Remove pom.xml references from build.gradle and release-please-config.json
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/1323)