### PR TITLE
Update CI build pool name to '1es-ubuntu-latest-m'

### DIFF
--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -20,8 +20,7 @@ extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: ubuntu-latest
+      name: 1es-ubuntu-latest-m
       os: linux
     sdl:
       sourceAnalysisPool:


### PR DESCRIPTION
Running into heap space issues on the beta build, switching to a more powerful agent. Mirrors a change made in #1194 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/1335)