### PR TITLE
Fix malformed YAML in ci-build.yml Configure Maven settings step

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -77,9 +77,9 @@ extends:
                 displayName: Import GPG signing key
 
               - pwsh: |
-$props = Get-Content local.properties -Raw
-$keyId = ($props | Select-String -Pattern 'signing\.keyId=([^\r\n]+)').Matches.Groups[1].Value.Trim()
-$keyPassword = ($props | Select-String -Pattern 'signing\.password=([^\r\n]+)').Matches.Groups[1].Value.Trim()
+                  $props = Get-Content local.properties -Raw
+                  $keyId = ($props | Select-String -Pattern 'signing\.keyId=([^\r\n]+)').Matches.Groups[1].Value.Trim()
+                  $keyPassword = ($props | Select-String -Pattern 'signing\.password=([^\r\n]+)').Matches.Groups[1].Value.Trim()
                   $settingsXml = @"
                   <settings>
                     <mirrors>


### PR DESCRIPTION
## Summary
Fixes malformed YAML in `.azure-pipelines/ci-build.yml`.

In the **Configure Maven settings** step, the first three PowerShell lines (``, ``, ``) were at column 0 instead of being indented into the `pwsh: |` block scalar. Block-scalar content must be indented deeper than its parent key, so those column-0 lines broke YAML parsing.

## Change
Indented those three lines to 18 spaces to align with the rest of the script block (e.g. `\ = @"`).

## Validation
- `yaml.safe_load()` now parses the file successfully (previously failed).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/1368)