### PR TITLE
Remove Gradle .module files from Maven package validation

### DIFF
--- a/scripts/validatePackageContents.ps1
+++ b/scripts/validatePackageContents.ps1
@@ -26,8 +26,6 @@ $expectedFiles = @(
   "-javadoc.jar.asc",
   "-sources.jar",
   "-sources.jar.asc",
-  ".module",
-  ".module.asc",
   ".pom",
   ".pom.asc",
   ".jar",


### PR DESCRIPTION
## Summary
Fixes a package-validation failure in the CI build:

```
Expected file microsoft-graph-beta-6.60.1.module not found in package.
##[error]PowerShell exited with code '1'.
```

## Root cause
`scripts/validatePackageContents.ps1` expected `.module` and `.module.asc` files. These are **Gradle Module Metadata** artifacts. The pipeline builds and publishes with **Maven** (`./mvnw`), which does not generate `.module` files. This mismatch was introduced during the Gradle to Maven ESRP migration.

## Change
Removed `.module` and `.module.asc` from the expected-files list. The remaining validated artifacts (`.jar`, `-sources.jar`, `-javadoc.jar`, `.pom` and their `.asc` signatures) are all produced by the Maven build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/1370)