### PR TITLE
Use Maven task in release pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -110,21 +110,53 @@ extends:
                 inputs:
                   artifactsFeeds: 'GraphDeveloperExperiences_Public'
 
-              - script: ./mvnw install -Psigning --no-transfer-progress
+              - task: Maven@4
                 displayName: Publish to local Maven for verification
                 condition: contains(variables['build.sourceBranch'], 'refs/tags/v')
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'install'
+                  options: '-Psigning --no-transfer-progress'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw install -Psigning --no-transfer-progress
+              - task: Maven@4
                 displayName: Publish to local Maven for verification
                 condition: not(contains(variables['build.sourceBranch'], 'refs/tags/v'))
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'install'
+                  options: '-Psigning --no-transfer-progress'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw deploy -Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy
+              - task: Maven@4
                 displayName: Stage artifacts for ESRP
                 condition: contains(variables['build.sourceBranch'], 'refs/tags/v')
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'deploy'
+                  options: '-Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
-              - script: ./mvnw deploy -Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy
+              - task: Maven@4
                 displayName: Stage artifacts for ESRP
                 condition: not(contains(variables['build.sourceBranch'], 'refs/tags/v'))
+                inputs:
+                  mavenPomFile: 'pom.xml'
+                  goals: 'deploy'
+                  options: '-Psigning --no-transfer-progress -DaltDeploymentRepository=ADO::default::file://$(Build.SourcesDirectory)/target/staging-deploy'
+                  publishJUnitResults: false
+                  javaHomeOption: 'JDKVersion'
+                  jdkVersionOption: '1.21'
+                  jdkArchitectureOption: 'x64'
 
               - pwsh: |
                   $pomXml = [xml](Get-Content pom.xml -Raw)


### PR DESCRIPTION
## Summary
- replace release pipeline Maven wrapper install/deploy commands with `Maven@4` tasks
- preserve signing, network-isolated Azure Artifacts mirror/authentication, branch conditions, and ESRP staging behavior
- explicitly retain Java 21 and disable JUnit publishing for these packaging steps

## Validation
- parsed `.azure-pipelines/ci-build.yml` successfully as YAML
- confirmed Azure Pipelines no longer invokes `./mvnw`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/1376)